### PR TITLE
Use request cr changes

### DIFF
--- a/src/plugins/es_ui_shared/public/request/use_request.test.ts
+++ b/src/plugins/es_ui_shared/public/request/use_request.test.ts
@@ -141,9 +141,6 @@ describe('useRequest hook', () => {
         expect(hookResult.isLoading).toBe(false);
         expect(hookResult.error).toBe(getErrorResponse().error);
 
-        // NOTE: This emits the warning "You called act(async () => ...) without await", because
-        // sendRequest returns a Promise. We don't want to await the resolution of this Promise,
-        // because we want to assert against the hook state while the Promise is pending.
         act(() => {
           hookResult.sendRequest();
         });
@@ -179,9 +176,6 @@ describe('useRequest hook', () => {
         expect(hookResult.isLoading).toBe(false);
         expect(hookResult.data).toBe(getSuccessResponse().data);
 
-        // NOTE: This emits the warning "You called act(async () => ...) without await", because
-        // sendRequest returns a Promise. We don't want to await the resolution of this Promise,
-        // because we want to assert against the hook state while the Promise is pending.
         act(() => {
           hookResult.sendRequest();
         });
@@ -231,10 +225,6 @@ describe('useRequest hook', () => {
       });
 
       it('resets the pollIntervalMs', async () => {
-        // NOTE: This tests emits the warning "You called act(async () => ...) without await", because
-        // sendRequest returns a Promise. We don't want to await the resolution of this Promise,
-        // because we want to assert against the hook state while the Promise is pending.
-
         const { setupSuccessRequest, advanceTime, hookResult, getSendRequestSpy } = helpers;
         const DOUBLE_REQUEST_TIME = REQUEST_TIME * 2 + 50; // We add 50 to avoid a race condition
         setupSuccessRequest({ pollIntervalMs: DOUBLE_REQUEST_TIME });
@@ -242,6 +232,7 @@ describe('useRequest hook', () => {
         // The initial request resolves, and then we'll immediately send a new one manually...
         await advanceTime(REQUEST_TIME);
         expect(getSendRequestSpy().callCount).toBe(1);
+
         act(() => {
           hookResult.sendRequest();
         });
@@ -260,10 +251,6 @@ describe('useRequest hook', () => {
       });
 
       it(`doesn't block requests that are in flight`, async () => {
-        // NOTE: This test emits the warning "You called act(async () => ...) without await", because
-        // sendRequest returns a Promise. We don't want to await the resolution of this Promise,
-        // because we want to assert against the hook state while the Promise is pending.
-
         const {
           setupSuccessRequest,
           advanceTime,

--- a/src/plugins/es_ui_shared/public/request/use_request.test.ts
+++ b/src/plugins/es_ui_shared/public/request/use_request.test.ts
@@ -47,10 +47,11 @@ describe('useRequest hook', () => {
         await advanceTime(REQUEST_TIME);
         expect(getSendRequestSpy().callCount).toBe(1);
 
-        await advanceTime(REQUEST_TIME);
+        // We need to advance (1) the pollIntervalMs and (2) the request time
+        await advanceTime(REQUEST_TIME * 2);
         expect(getSendRequestSpy().callCount).toBe(2);
 
-        await advanceTime(REQUEST_TIME);
+        await advanceTime(REQUEST_TIME * 2);
         expect(getSendRequestSpy().callCount).toBe(3);
       });
     });

--- a/src/plugins/es_ui_shared/public/request/use_request.test.ts
+++ b/src/plugins/es_ui_shared/public/request/use_request.test.ts
@@ -236,7 +236,7 @@ describe('useRequest hook', () => {
         // because we want to assert against the hook state while the Promise is pending.
 
         const { setupSuccessRequest, advanceTime, hookResult, getSendRequestSpy } = helpers;
-        const DOUBLE_REQUEST_TIME = REQUEST_TIME * 2;
+        const DOUBLE_REQUEST_TIME = REQUEST_TIME * 2 + 50; // We add 50 to avoid a race condition
         setupSuccessRequest({ pollIntervalMs: DOUBLE_REQUEST_TIME });
 
         // The initial request resolves, and then we'll immediately send a new one manually...
@@ -253,7 +253,7 @@ describe('useRequest hook', () => {
           hookResult.sendRequest();
         });
 
-        // At this point, we've moved forward 3s. The poll is set at 2s. If sendRequest didn't
+        // At this point, we've moved forward 3000 ms. The poll is set at 2050s. If sendRequest didn't
         // reset the poll, the request call count would be 4, not 3.
         await advanceTime(REQUEST_TIME);
         expect(getSendRequestSpy().callCount).toBe(3);


### PR DESCRIPTION
This PR adds the refactor of the useRequest() hook to not use references but callBacks to define the handlers.
Happy to walk over the code with you tomorrow if you have any questions on why this is a better approach on defining handlers and dependencies.

I also fixed the bug where providing new object `query` or `body` triggered infinite request sent.