### PR TITLE
[Upgrade Assistant] Support completion state on overview page

### DIFF
--- a/x-pack/plugins/upgrade_assistant/__jest__/client_integration/overview/fix_issues_step/fix_issues_step.test.tsx
+++ b/x-pack/plugins/upgrade_assistant/__jest__/client_integration/overview/fix_issues_step/fix_issues_step.test.tsx
@@ -42,6 +42,37 @@ describe('Overview - Fix deprecation issues step', () => {
     server.restore();
   });
 
+  describe('Step status', () => {
+    test('Its complete when there are no critical deprecations', async () => {
+      httpRequestsMockHelpers.setLoadEsDeprecationsResponse(mockedResponses.esDeprecationsEmpty);
+
+      await act(async () => {
+        const deprecationService = deprecationsServiceMock.createStartContract();
+        deprecationService.getAllDeprecations = jest.fn().mockRejectedValue([]);
+
+        testBed = await setupOverviewPage({
+          services: {
+            core: {
+              deprecations: deprecationService,
+            },
+          },
+        });
+      });
+
+      const { exists, component } = testBed;
+
+      component.update();
+
+      expect(exists(`fixIssuesStep-complete`)).toBe(true);
+    });
+
+    test('Its incomplete when there are critical deprecations', async () => {
+      const { exists } = testBed;
+
+      expect(exists(`fixIssuesStep-incomplete`)).toBe(true);
+    });
+  });
+
   describe('ES deprecations', () => {
     test('Shows deprecation warning and critical counts', () => {
       const { exists, find } = testBed;

--- a/x-pack/plugins/upgrade_assistant/__jest__/client_integration/overview/fix_logs_step/fix_logs_step.test.tsx
+++ b/x-pack/plugins/upgrade_assistant/__jest__/client_integration/overview/fix_logs_step/fix_logs_step.test.tsx
@@ -33,14 +33,49 @@ describe('Overview - Fix deprecation logs step', () => {
     server.restore();
   });
 
+  describe('Step status', () => {
+    test('Its complete when there are no deprecation logs since last checkpoint', async () => {
+      httpRequestsMockHelpers.setUpdateDeprecationLoggingResponse(getLoggingResponse(true));
+
+      httpRequestsMockHelpers.setLoadDeprecationLogsCountResponse({
+        count: 0,
+      });
+
+      await act(async () => {
+        testBed = await setupOverviewPage();
+      });
+
+      const { exists, component } = testBed;
+
+      component.update();
+
+      expect(exists(`fixLogsStep-complete`)).toBe(true);
+    });
+
+    test('Its incomplete when there are deprecation logs since last checkpoint', async () => {
+      httpRequestsMockHelpers.setUpdateDeprecationLoggingResponse(getLoggingResponse(true));
+
+      httpRequestsMockHelpers.setLoadDeprecationLogsCountResponse({
+        count: 5,
+      });
+
+      await act(async () => {
+        testBed = await setupOverviewPage();
+      });
+
+      const { exists, component } = testBed;
+
+      component.update();
+
+      expect(exists(`fixLogsStep-incomplete`)).toBe(true);
+    });
+  });
+
   describe('Step 1 - Toggle log writing and collecting', () => {
     test('toggles deprecation logging', async () => {
       const { find, actions } = testBed;
 
-      httpRequestsMockHelpers.setUpdateDeprecationLoggingResponse({
-        isDeprecationLogIndexingEnabled: false,
-        isDeprecationLoggingEnabled: false,
-      });
+      httpRequestsMockHelpers.setUpdateDeprecationLoggingResponse(getLoggingResponse(false));
 
       expect(find('deprecationLoggingToggle').props()['aria-checked']).toBe(true);
 

--- a/x-pack/plugins/upgrade_assistant/public/application/components/overview/backup_step/backup_step.tsx
+++ b/x-pack/plugins/upgrade_assistant/public/application/components/overview/backup_step/backup_step.tsx
@@ -23,10 +23,13 @@ interface Props extends OverviewStepsProps {
 }
 
 export const getBackupStep = ({ cloud, isComplete, setIsComplete }: Props): EuiStepProps => {
+  const status = isComplete ? 'complete' : 'incomplete';
+
   if (cloud?.isCloudEnabled) {
     return {
+      status,
       title,
-      status: isComplete ? 'complete' : 'incomplete',
+      'data-test-subj': `backupStep-${status}`,
       children: (
         <CloudBackup
           cloudSnapshotsUrl={`${cloud!.deploymentUrl}/elasticsearch/snapshots`}

--- a/x-pack/plugins/upgrade_assistant/public/application/components/overview/backup_step/backup_step.tsx
+++ b/x-pack/plugins/upgrade_assistant/public/application/components/overview/backup_step/backup_step.tsx
@@ -11,25 +11,18 @@ import type { EuiStepProps } from '@elastic/eui/src/components/steps/step';
 
 import type { CloudSetup } from '../../../../../../cloud/public';
 import { OnPremBackup } from './on_prem_backup';
-import { CloudBackup, CloudBackupStatusResponse } from './cloud_backup';
+import { CloudBackup } from './cloud_backup';
+import type { OverviewStepsProps } from '../../types';
 
 const title = i18n.translate('xpack.upgradeAssistant.overview.backupStepTitle', {
   defaultMessage: 'Back up your data',
 });
 
-interface Props {
-  isComplete: boolean;
-  setIsComplete: (isComplete: boolean) => void;
+interface Props extends OverviewStepsProps {
   cloud?: CloudSetup;
-  cloudBackupStatusResponse?: CloudBackupStatusResponse;
 }
 
-export const getBackupStep = ({
-  cloud,
-  cloudBackupStatusResponse,
-  isComplete,
-  setIsComplete,
-}: Props): EuiStepProps => {
+export const getBackupStep = ({ cloud, isComplete, setIsComplete }: Props): EuiStepProps => {
   if (cloud?.isCloudEnabled) {
     return {
       title,
@@ -37,7 +30,7 @@ export const getBackupStep = ({
       children: (
         <CloudBackup
           cloudSnapshotsUrl={`${cloud!.deploymentUrl}/elasticsearch/snapshots`}
-          setIsComplete={setIsComplete!}
+          setIsComplete={setIsComplete}
         />
       ),
     };

--- a/x-pack/plugins/upgrade_assistant/public/application/components/overview/backup_step/cloud_backup.tsx
+++ b/x-pack/plugins/upgrade_assistant/public/application/components/overview/backup_step/cloud_backup.tsx
@@ -20,12 +20,7 @@ import {
   EuiCallOut,
 } from '@elastic/eui';
 
-import { CloudBackupStatus } from '../../../../../common/types';
-import { UseRequestResponse } from '../../../../shared_imports';
-import { ResponseError } from '../../../lib/api';
 import { useAppContext } from '../../../app_context';
-
-export type CloudBackupStatusResponse = UseRequestResponse<CloudBackupStatus, ResponseError>;
 
 interface Props {
   cloudSnapshotsUrl: string;
@@ -51,7 +46,8 @@ export const CloudBackup: React.FunctionComponent<Props> = ({
   // Tell overview whether the step is complete or not.
   useEffect(() => {
     setIsComplete(data?.isBackedUp ?? false);
-  }, [data, setIsComplete]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [data]);
 
   if (isInitialRequest && isLoading) {
     return <EuiLoadingContent lines={3} />;

--- a/x-pack/plugins/upgrade_assistant/public/application/components/overview/fix_issues_step/es_stats/es_stats.tsx
+++ b/x-pack/plugins/upgrade_assistant/public/application/components/overview/fix_issues_step/es_stats/es_stats.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import React, { FunctionComponent } from 'react';
+import React, { FunctionComponent, useEffect, useMemo } from 'react';
 import { useHistory } from 'react-router-dom';
 
 import {
@@ -60,7 +60,11 @@ const i18nTexts = {
     }),
 };
 
-export const ESDeprecationStats: FunctionComponent = () => {
+interface Props {
+  setCriticalIssuesCount: (count: number) => void;
+}
+
+export const ESDeprecationStats: FunctionComponent<Props> = ({ setCriticalIssuesCount }) => {
   const history = useHistory();
   const {
     services: { api },
@@ -68,10 +72,22 @@ export const ESDeprecationStats: FunctionComponent = () => {
 
   const { data: esDeprecations, isLoading, error } = api.useLoadEsDeprecations();
 
-  const warningDeprecations =
-    esDeprecations?.deprecations?.filter((deprecation) => deprecation.isCritical === false) || [];
-  const criticalDeprecations =
-    esDeprecations?.deprecations?.filter((deprecation) => deprecation.isCritical) || [];
+  const warningDeprecations = useMemo(
+    () =>
+      esDeprecations?.deprecations?.filter((deprecation) => deprecation.isCritical === false) || [],
+    [esDeprecations]
+  );
+  const criticalDeprecations = useMemo(
+    () => esDeprecations?.deprecations?.filter((deprecation) => deprecation.isCritical) || [],
+    [esDeprecations]
+  );
+
+  useEffect(() => {
+    if (!isLoading && !error) {
+      setCriticalIssuesCount(criticalDeprecations.length);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [criticalDeprecations, isLoading, error]);
 
   const hasWarnings = warningDeprecations.length > 0;
   const hasCritical = criticalDeprecations.length > 0;

--- a/x-pack/plugins/upgrade_assistant/public/application/components/overview/fix_issues_step/kibana_stats/kibana_stats.tsx
+++ b/x-pack/plugins/upgrade_assistant/public/application/components/overview/fix_issues_step/kibana_stats/kibana_stats.tsx
@@ -68,7 +68,11 @@ const i18nTexts = {
     }),
 };
 
-export const KibanaDeprecationStats: FunctionComponent = () => {
+interface Props {
+  setCriticalIssuesCount: (count: number) => void;
+}
+
+export const KibanaDeprecationStats: FunctionComponent<Props> = ({ setCriticalIssuesCount }) => {
   const history = useHistory();
   const {
     services: {
@@ -103,6 +107,14 @@ export const KibanaDeprecationStats: FunctionComponent = () => {
     kibanaDeprecations?.filter((deprecation) => deprecation.level === 'warning')?.length ?? 0;
   const criticalDeprecationsCount =
     kibanaDeprecations?.filter((deprecation) => deprecation.level === 'critical')?.length ?? 0;
+
+  useEffect(() => {
+    if (!isLoading && !error) {
+      setCriticalIssuesCount(criticalDeprecationsCount);
+    }
+
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [criticalDeprecationsCount, isLoading, error]);
 
   const hasCritical = criticalDeprecationsCount > 0;
   const hasWarnings = warningDeprecationsCount > 0;

--- a/x-pack/plugins/upgrade_assistant/public/application/components/overview/fix_logs_step/deprecations_count_checkpoint/deprecations_count_checkpoint.tsx
+++ b/x-pack/plugins/upgrade_assistant/public/application/components/overview/fix_logs_step/deprecations_count_checkpoint/deprecations_count_checkpoint.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import React, { FunctionComponent, useState } from 'react';
+import React, { FunctionComponent, useState, useEffect } from 'react';
 import moment from 'moment-timezone';
 import { FormattedDate, FormattedTime, FormattedMessage } from '@kbn/i18n/react';
 
@@ -64,7 +64,11 @@ const getPreviousCheckpointDate = () => {
   return now;
 };
 
-export const DeprecationsCountCheckpoint: FunctionComponent = () => {
+interface Props {
+  setIsComplete: (isComplete: boolean) => void;
+}
+
+export const DeprecationsCountCheckpoint: FunctionComponent<Props> = ({ setIsComplete }) => {
   const {
     services: { api },
   } = useAppContext();
@@ -84,6 +88,13 @@ export const DeprecationsCountCheckpoint: FunctionComponent = () => {
     setPreviousCheck(now);
     localStorage.set(LS_SETTING_ID, now);
   };
+
+  useEffect(() => {
+    if (!isLoading && !error) {
+      setIsComplete(warningsCount === 0);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [error, isLoading, warningsCount]);
 
   if (isInitialRequest && isLoading) {
     return <EuiLoadingContent lines={6} />;

--- a/x-pack/plugins/upgrade_assistant/public/application/components/overview/fix_logs_step/fix_logs_step.tsx
+++ b/x-pack/plugins/upgrade_assistant/public/application/components/overview/fix_logs_step/fix_logs_step.tsx
@@ -15,6 +15,7 @@ import { ExternalLinks } from './external_links';
 import { DeprecationsCountCheckpoint } from './deprecations_count_checkpoint';
 import { useDeprecationLogging } from './use_deprecation_logging';
 import { DeprecationLoggingToggle } from './deprecation_logging_toggle';
+import type { OverviewStepsProps } from '../../types';
 
 const i18nTexts = {
   identifyStepTitle: i18n.translate('xpack.upgradeAssistant.overview.identifyStepTitle', {
@@ -47,7 +48,7 @@ const i18nTexts = {
   ),
 };
 
-const FixLogsStep: FunctionComponent = () => {
+const FixLogsStep: FunctionComponent<OverviewStepsProps> = ({ setIsComplete }) => {
   const state = useDeprecationLogging();
 
   return (
@@ -88,17 +89,20 @@ const FixLogsStep: FunctionComponent = () => {
             <h4>{i18nTexts.deprecationsCountCheckpointTitle}</h4>
           </EuiText>
           <EuiSpacer size="m" />
-          <DeprecationsCountCheckpoint />
+          <DeprecationsCountCheckpoint setIsComplete={setIsComplete} />
         </>
       )}
     </>
   );
 };
 
-export const getFixLogsStep = (): EuiStepProps => {
+export const getFixLogsStep = ({ isComplete, setIsComplete }: OverviewStepsProps): EuiStepProps => {
+  const status = isComplete ? 'complete' : 'incomplete';
+
   return {
+    status,
     title: i18nTexts.identifyStepTitle,
-    status: 'incomplete',
-    children: <FixLogsStep />,
+    'data-test-subj': `fixLogsStep-${status}`,
+    children: <FixLogsStep isComplete={isComplete} setIsComplete={setIsComplete} />,
   };
 };

--- a/x-pack/plugins/upgrade_assistant/public/application/components/overview/fix_logs_step/fix_logs_step.tsx
+++ b/x-pack/plugins/upgrade_assistant/public/application/components/overview/fix_logs_step/fix_logs_step.tsx
@@ -48,7 +48,7 @@ const i18nTexts = {
   ),
 };
 
-const FixLogsStep: FunctionComponent<OverviewStepsProps> = ({ setIsComplete }) => {
+const FixLogsStep: FunctionComponent<Partial<OverviewStepsProps>> = ({ setIsComplete }) => {
   const state = useDeprecationLogging();
 
   return (
@@ -89,7 +89,7 @@ const FixLogsStep: FunctionComponent<OverviewStepsProps> = ({ setIsComplete }) =
             <h4>{i18nTexts.deprecationsCountCheckpointTitle}</h4>
           </EuiText>
           <EuiSpacer size="m" />
-          <DeprecationsCountCheckpoint setIsComplete={setIsComplete} />
+          <DeprecationsCountCheckpoint setIsComplete={setIsComplete!} />
         </>
       )}
     </>
@@ -103,6 +103,6 @@ export const getFixLogsStep = ({ isComplete, setIsComplete }: OverviewStepsProps
     status,
     title: i18nTexts.identifyStepTitle,
     'data-test-subj': `fixLogsStep-${status}`,
-    children: <FixLogsStep isComplete={isComplete} setIsComplete={setIsComplete} />,
+    children: <FixLogsStep setIsComplete={setIsComplete} />,
   };
 };

--- a/x-pack/plugins/upgrade_assistant/public/application/components/overview/overview.tsx
+++ b/x-pack/plugins/upgrade_assistant/public/application/components/overview/overview.tsx
@@ -112,8 +112,15 @@ export const Overview: FunctionComponent = () => {
               isComplete: isStepComplete('backup'),
               setIsComplete: setCompletedStep.bind(null, 'backup'),
             }),
-            getFixIssuesStep({ nextMajor }),
-            getFixLogsStep(),
+            getFixIssuesStep({
+              nextMajor,
+              isComplete: isStepComplete('fix_issues'),
+              setIsComplete: setCompletedStep.bind(null, 'fix_issues'),
+            }),
+            getFixLogsStep({
+              isComplete: isStepComplete('fix_logs'),
+              setIsComplete: setCompletedStep.bind(null, 'fix_logs'),
+            }),
             getUpgradeStep({ docLinks, nextMajor }),
           ]}
         />

--- a/x-pack/plugins/upgrade_assistant/public/application/components/types.ts
+++ b/x-pack/plugins/upgrade_assistant/public/application/components/types.ts
@@ -31,3 +31,8 @@ export interface DeprecationLoggingPreviewProps {
   resendRequest: () => void;
   toggleLogging: () => void;
 }
+
+export interface OverviewStepsProps {
+  isComplete: boolean;
+  setIsComplete: (isComplete: boolean) => void;
+}


### PR DESCRIPTION
Heya!

This PR adds some of the remaining work for https://github.com/elastic/kibana/issues/110737 in order to support for step completion for fix_logs and fix_issues steps, along with their respective tests. It's missing tests for cloud step since it seems there was a conflict along the way after your previous PR got merged.

I ended up removing the setIsCompleted from all the useEffects because when invoked the overview component gets re-rendered and the .bind functions passed to the steps definitions have a new fn instance. We either will have to memoize them or simply recur to ignore the setIsCompleted from the dependencies array.
